### PR TITLE
Git template directory

### DIFF
--- a/git_template/hooks/ctags
+++ b/git_template/hooks/ctags
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+set -e
+PATH="/usr/local/bin:$PATH"
+trap "rm -f .git/tags.$$" EXIT
+ctags --tag-relative -Rf.git/tags.$$ --exclude=.git --languages=-javascript,sql
+mv .git/tags.$$ .git/tags

--- a/git_template/hooks/post-checkout
+++ b/git_template/hooks/post-checkout
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+.git/hooks/ctags >/dev/null 2>&1 &

--- a/git_template/hooks/post-commit
+++ b/git_template/hooks/post-commit
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+.git/hooks/ctags >/dev/null 2>&1 &

--- a/git_template/hooks/post-merge
+++ b/git_template/hooks/post-merge
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+.git/hooks/ctags >/dev/null 2>&1 &

--- a/git_template/hooks/post-rewrite
+++ b/git_template/hooks/post-rewrite
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+.git/hooks/ctags >/dev/null 2>&1 &

--- a/git_template/hooks/pre-commit
+++ b/git_template/hooks/pre-commit
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+git diff --exit-code --cached -- Gemfile Gemfile.lock > /dev/null || bundle check

--- a/gitconfig
+++ b/gitconfig
@@ -1,0 +1,2 @@
+[init]
+  templatedir = ~/.git_template


### PR DESCRIPTION
## Effortless ctags

Credits to Tim Pope for [this blog post](http://tbaggery.com/2011/08/08/effortless-ctags-with-git.html)

TL;DR: Basically, you’ll never have to manually run Ctags on a Git repository again.

Requirements: git & ctags (duhhh), and setting the ctags default file to `.git/ctags` instead of `ctags` ([vim-fugitive](https://github.com/tpope/vim-fugitive) already does that by default)
## Preventing bundler errors

pre-commit hook prevents anyone to commit an update to Gemfile, without updating and commiting as well the corresponding Gemfile.lock

TL;DR: No one will ever forget to run `bundle install`, ever
