### PR TITLE
Removes git hooks

### DIFF
--- a/git_template/hooks/ctags
+++ b/git_template/hooks/ctags
@@ -1,7 +1,0 @@
-#!/bin/sh
-
-set -e
-PATH="/usr/local/bin:$PATH"
-trap "rm -f .git/tags.$$" EXIT
-ctags --tag-relative -Rf.git/tags.$$ --exclude=.git --languages=-javascript,sql
-mv .git/tags.$$ .git/tags

--- a/git_template/hooks/post-checkout
+++ b/git_template/hooks/post-checkout
@@ -1,3 +1,0 @@
-#!/bin/sh
-
-.git/hooks/ctags >/dev/null 2>&1 &

--- a/git_template/hooks/post-commit
+++ b/git_template/hooks/post-commit
@@ -1,3 +1,0 @@
-#!/bin/sh
-
-.git/hooks/ctags >/dev/null 2>&1 &

--- a/git_template/hooks/post-merge
+++ b/git_template/hooks/post-merge
@@ -1,3 +1,0 @@
-#!/bin/sh
-
-.git/hooks/ctags >/dev/null 2>&1 &

--- a/git_template/hooks/post-rewrite
+++ b/git_template/hooks/post-rewrite
@@ -1,3 +1,0 @@
-#!/bin/sh
-
-.git/hooks/ctags >/dev/null 2>&1 &

--- a/git_template/hooks/pre-commit
+++ b/git_template/hooks/pre-commit
@@ -1,3 +1,0 @@
-#!/bin/sh
-
-git diff --exit-code --cached -- Gemfile Gemfile.lock > /dev/null || bundle check


### PR DESCRIPTION
These are hard to manage via symlinks. They are currently not working, since
rcup will create symlinks to each hook by default (instead of copying them),
and git won't run them this way (for security reasons)

Also, it's hard to share git hooks, since each of us might want different
features for each one.

I'm considering using something like
[this](https://github.com/icefox/git-hooks) which might make it easier, but in
the meantime, these are useless here